### PR TITLE
feat(profile-page): profile-Page is ready !!!

### DIFF
--- a/src/pages/my-profile/index.jsx
+++ b/src/pages/my-profile/index.jsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+// import { useState } from "react";
+import Layout from "@/components/layout/Layout";
+import UserInfo from "@/components/UserInfo";
+import MyItems from "@/components/MyItems";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+// import { useTranslation } from "react-i18next";
+const ProfileInfo = () => {
+    return (
+        <Layout>
+            <UserInfo />
+            <MyItems />
+        </Layout>
+    );
+};
+export async function getStaticProps({ locale }) {
+    return {
+        props: {
+            ...(await serverSideTranslations(locale, ["common"])),
+            // Will be passed to the page component as props
+        },
+    };
+}
+
+export default ProfileInfo;


### PR DESCRIPTION
to close Issue #37
The desktop:
![image](https://user-images.githubusercontent.com/95312230/182343364-4005f319-ac94-4b19-9f26-d6e69f250312.png)

The Tablet:
![image](https://user-images.githubusercontent.com/95312230/182343487-8b5cf6f6-fe01-4527-a4ca-651cf2c8f721.png)


There are 2 commented lines for future use, you can just ignore them while doing the review.
Regarding the width and any other styling issues, it was discussed to be edited later, even though I see them suitable.

This page was simple. You can check the code down below for further information
```jsx
import * as React from "react";
// import { useState } from "react";
import Layout from "@/components/layout/Layout";
import UserInfo from "@/components/UserInfo";
import MyItems from "@/components/MyItems";
import { serverSideTranslations } from "next-i18next/serverSideTranslations";
// import { useTranslation } from "react-i18next";
const ProfileInfo = () => {
    return (
        <Layout>
            <UserInfo />
            <MyItems />
        </Layout>
    );
};
export async function getStaticProps({ locale }) {
    return {
        props: {
            ...(await serverSideTranslations(locale, ["common"])),
            // Will be passed to the page component as props
        },
    };
}

export default ProfileInfo;

```

# Related Issue

- Resolve #37